### PR TITLE
Change ottr-preview action version in workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -145,7 +145,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run render
-      uses: ottrproject/ottr-preview@main
+      uses: ottrproject/ottr-preview@flatten-zip
       with:
         toggle_website: ${{needs.yaml-check.outputs.toggle_website}}
         docker_image: ${{needs.yaml-check.outputs.rendering_docker_image}}


### PR DESCRIPTION
Going to test the comprehensive preview download option that Adam is working on in ottr-preview (flatten-zip branch)